### PR TITLE
fix: resolve Xcode 15 network runtime warning

### DIFF
--- a/Sources/Uploadcare/UploadAPI.swift
+++ b/Sources/Uploadcare/UploadAPI.swift
@@ -544,7 +544,7 @@ extension UploadAPI {
 		_ onProgress: TaskProgressBlock? = nil,
 		_ completionHandler: @escaping TaskResultCompletionHandler
 	) -> UploadTaskable {
-		let urlRequest = createDirectUploadRequest(files: files, store: store, metadata: metadata, uploadSignature: uploadSignature)
+		var urlRequest = createDirectUploadRequest(files: files, store: store, metadata: metadata, uploadSignature: uploadSignature)
 
         // writing data to temp file
         let tempDir = FileManager.default.temporaryDirectory
@@ -552,6 +552,8 @@ extension UploadAPI {
 
         if let data = urlRequest.httpBody {
             try? data.write(to: localURL)
+            // To avoid a runtime warning in Xcode 15, the given `URLRequest` should have a nil `HTTPBody`
+            urlRequest.httpBody = nil
         }
 
         let uploadTask: URLSessionUploadTask
@@ -640,7 +642,7 @@ extension UploadAPI {
 	///   - completionHandler: Completion handler.
 	#if !os(Linux)
 	@discardableResult
-	internal func directUploadInForeground(
+	public func directUploadInForeground(
 		files: [String: Data],
 		store: StoringBehavior? = nil,
 		metadata: [String: String]? = nil,


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->
[Related issue](https://github.com/uploadcare/uploadcare-swift/issues/128)

<!-- Write a brief description of the changes introduced by this PR -->
Resolve Xcode 15 network runtime warning: upload tasks should not contain body data

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
