### PR TITLE
DOCS-1156: Update README with subdomain examples (uploadcare-swift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Check the [Upload API documentation](https://github.com/uploadcare/uploadcare-sw
 Example of uploads:
 
 ```swift
-guard let url = URL(string: "https://demo.ucarecdn.net/46528d0d-323c-42d7-beab-2fdc5e7077ba/") else { return }
+guard let url = URL(string: "https://demo.ucarecd.net/46528d0d-323c-42d7-beab-2fdc5e7077ba/") else { return }
 guard let data = try? Data(contentsOf: url) else { return }
 
 // You can create an UploadedFile object to operate with it


### PR DESCRIPTION
Summary:
Switch generic CDN example in README from ucarecdn.com to demo.ucarecd.net

Changes:
• README.md – updated one example URL only

Notes:
• Badges, logos, and images left untouched (live assets)
• README-only change

Resolves: DOCS-1156

Note:
CI failures are due to fork PRs running without API keys (Public key not found). Safe to merge once approved; alternatively I can reopen from an internal branch when write access is granted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Swift "Example of uploads" snippet to use the demo.ucarecd.net URL instead of the previous production-style URL.
  * Documentation-only change — no code, behavior, API, or public declaration changes; applications continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->