### PR TITLE
DOCS-1156: Update README with subdomain examples (uploadcare-swift)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Check the [Upload API documentation](https://github.com/uploadcare/uploadcare-sw
 Example of uploads:
 
 ```swift
-guard let url = URL(string: "https://ucarecdn.com/46528d0d-323c-42d7-beab-2fdc5e7077ba/") else { return }
+guard let url = URL(string: "https://demo.ucarecd.net/46528d0d-323c-42d7-beab-2fdc5e7077ba/") else { return }
 guard let data = try? Data(contentsOf: url) else { return }
 
 // You can create an UploadedFile object to operate with it


### PR DESCRIPTION
Summary: 
Switch generic example URL in README from ucarecdn.com to demo.ucarecd.net.

Notes: 
Docs-only; badges/logos/images left intact. One README change, one commit.

Resolves: DOCS-1156


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the Upload API example to use a demo domain (demo.ucarecd.net) for uploaded file URLs, improving clarity for users testing uploads.
  * Only the example URL changed; all other example code remains the same.
  * No impact on runtime behavior or public APIs. No action required for existing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->